### PR TITLE
suggestions

### DIFF
--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/ExecutorImpl.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/ExecutorImpl.scala
@@ -1,0 +1,72 @@
+package edu.gemini.seqexec.server
+
+import java.util.concurrent.{ScheduledExecutorService, ScheduledThreadPoolExecutor}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
+
+import scalaz._
+import Scalaz._
+
+import edu.gemini.pot.sp.SPObservationID
+import edu.gemini.seqexec.server.Executor._
+import edu.gemini.seqexec.server.SeqexecFailure._
+import edu.gemini.spModel.config2.{Config, ConfigSequence, ItemKey}
+import edu.gemini.spModel.obscomp.InstConstants.INSTRUMENT_NAME_PROP
+import edu.gemini.spModel.seqcomp.SeqConfigNames.INSTRUMENT_KEY
+
+import scalaz.concurrent.Task
+
+/** An executor that maintains state in a pair of `TaskRef`s. */
+class ExecutorImpl private (cancelRef: TaskRef[Set[SPObservationID]], stateRef: TaskRef[Map[SPObservationID, Executor.ExecState]]) {
+
+  private def recordState(id: SPObservationID)(s: ExecState): Task[Unit] =
+    stateRef.modify(_ + ((id -> s)))
+
+  private def go(id: SPObservationID): Task[Boolean] = 
+    cancelRef.get.map(_(id))
+
+  private def initialExecState(sequenceConfig: ConfigSequence): ExecState =
+    ExecState.initial(sequenceConfig.getAllSteps.toList.map(Step.step))
+
+  // todo: it is an error to run a sequence with an existing ExecState != s
+  private def runSeq(id: SPObservationID, s: ExecState): Task[(ExecState, NonEmptyList[SeqexecFailure] \/ Unit)] =
+    cancelRef.modify(_ - id) *> recordState(id)(s) *> run(go(id), recordState(id))(s)
+
+  def start(id: SPObservationID, sequenceConfig: ConfigSequence): Task[(ExecState, NonEmptyList[SeqexecFailure] \/ Unit)] =
+    runSeq(id, initialExecState(sequenceConfig))
+
+  def continue(id: SPObservationID): Task[(Option[ExecState], NonEmptyList[SeqexecFailure] \/ Unit)] =
+    getState(id) >>= {
+      case -\/(e) => Task.now((None, NonEmptyList(e).left))
+      case \/-(s) => runSeq(id, s).map(_.leftMap(_.some))
+    }
+
+  def getState(id: SPObservationID): Task[SeqexecFailure \/ ExecState] =
+    stateRef.get.map(_.get(id) \/> InvalidOp("Sequence has not started."))
+
+  def stop(id: SPObservationID): Task[SeqexecFailure \/ Unit] =
+    getState(id) >>= {
+      case \/-(s) => cancelRef.modify(s => s + id).as(\/-(()))
+      case -\/(e) => Task.now(-\/(e))
+    }
+
+  def stateDescription(state: ExecState): String = {
+    "Completed " + state.completed.length + " steps out of " + (state.completed.length + state.remaining.length) +
+      ( state.completed.zipWithIndex.map(a => (a._1, a._2+1)) map {
+        case (Ok(StepResult(_,ObserveResult(label))), idx) => s"Step $idx completed with label $label"
+        case (Failed(result), idx) => s"Step $idx failed with error " + result.map(SeqexecFailure.explain).toList.mkString("\n", "\n", "")
+        case (Skipped, idx)        => s"Step $idx skipped"
+      }
+    ).mkString("\n", "\n", "")
+  }
+
+}
+
+object ExecutorImpl {
+ 
+  def newInstance: Task[ExecutorImpl] =
+    for {
+      cancel <- TaskRef.newTaskRef[Set[SPObservationID]](Set.empty)
+      state  <- TaskRef.newTaskRef[Map[SPObservationID, Executor.ExecState]](Map.empty)
+    } yield new ExecutorImpl(cancel, state)
+
+}

--- a/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TaskRef.scala
+++ b/bundle/edu.gemini.seqexec.server/src/main/scala/edu/gemini/seqexec/server/TaskRef.scala
@@ -1,0 +1,32 @@
+package edu.gemini.seqexec.server
+
+import scalaz.concurrent.Task
+
+/** A concurrent mutable cell for type A. */
+sealed trait TaskRef[A] {
+
+  /** Atomic modification. */
+  def modify(f: A => A): Task[Unit]
+  
+  /** Return the current value. */
+  def get: Task[A]
+
+  /** Replace the current value. */
+  def put(a: A): Task[Unit] = 
+    modify(_ => a)
+
+}
+
+object TaskRef {
+
+  /** Create a new TaskRef. */
+  def newTaskRef[A](a: A): Task[TaskRef[A]] =
+    Task.delay {
+      @volatile var value = a
+      new TaskRef[A] { ref =>
+        def get = Task.delay(a)
+        def modify(f: A => A) = Task.delay(ref.synchronized(value = f(a)))
+      }
+    }
+
+}


### PR DESCRIPTION
Hi Javier, see how this looks. It compiles but I haven't tried to run it. You can use the "merge from the commandline" instructions to try it on a branch.

Here is what I did:
- Turn `Executor` into a simple module of pure functions and remove the logic associated with tracking state. Move all that logic into `ExecutorImpl` in a new file.
- Change the `reportResult` to be a `Task` instead of a side-effecting function.
- Turn `ExecutorImpl` into a class exposing only pure functions. Track state via `TaskRef`, which is just a pure cell with a value that can be swapped out in a `Task`.
- Change `Commands` to be the only place we use unsafe `.run` and `.runAsync`, and change the handling to ensure that the results of computations are reported back (but not very well).
